### PR TITLE
Fixed the wrong color of the options in the drop-down list in dark mode

### DIFF
--- a/src/components/preferences.css
+++ b/src/components/preferences.css
@@ -145,6 +145,11 @@
     appearance: none;
 }
 
+.option-select > select > option {
+    color: var(--font-color);
+    background-color: var(--background-color);
+}
+
 ::-ms-expand {
     display: none;
 }


### PR DESCRIPTION
Hi, please review and test my change.

OS:

- Ubuntu 18.04.5 (4.4.0-19041-Microsoft) (WSL) on Windows 10 2004 10.0.19041.508
- Ubuntu 20.04.1 (5.4.0-48-generic)

Dev env:

- node v14.13.0
- npm v6.14.8
- Live Server 5.6.1

Browsers:

- Windows 10 2004 64 bit [10.0.19041.508] (19041.1.amd64fre.vb_release.191206-1406)
  - Firefox 80.0.1/81.0 64 bit
  - Google Chrome 85.0.4183.121 64 bit
- Windows 7 SP1 64 bit [6.1.7061] (7601.24214.amd64fre.win7sp1_ldr_escrow.180801-1700)
  - Google Chrome 49.0.2623.112 64 bit

Screenshot:

![screenshot_comparison](https://user-images.githubusercontent.com/29089388/94678519-3b79bb80-0351-11eb-8597-0a07388b8c94.png)

