### PR TITLE
Fix typo: s/Githu /Github /

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ It's hard to find a user-friendly and cross-platform tool to create lrc. So I ma
 
 ## How to use
 
-open [lrc-maker][lrc maker] to start. You can add the link to browser bookmark. It is easy to use.  
-Darg and drop the file in the page to load an audio file.  
+Open [lrc-maker][lrc maker] to start. You can add the link to browser bookmark. It is easy to use.
+Drag and drop the file in the page to load an audio file.
 Use the arrow key and space key to insert the timestamp.
 
-development branch links:
+Development branch links:
 
 -   https://magic-akari.github.io/lrc-maker/
 -   https://lrc-maker.vercel.app/

--- a/src/languages/en-US.ts
+++ b/src/languages/en-US.ts
@@ -10,7 +10,7 @@ export const language = {
         home: "home",
         editor: "editor",
         synchronizer: "synchronizer",
-        gist: "Githu Gist",
+        gist: "Github Gist",
         preferences: "preferences",
     },
 

--- a/src/languages/ja.ts
+++ b/src/languages/ja.ts
@@ -10,7 +10,7 @@ export const language = {
         home: "ホームページ",
         editor: "編集",
         synchronizer: "同期",
-        gist: "Githu Gist",
+        gist: "Github Gist",
         preferences: "設定",
     },
 

--- a/src/languages/zh-CN.ts
+++ b/src/languages/zh-CN.ts
@@ -10,7 +10,7 @@ export const language = {
         home: "主页",
         editor: "编辑",
         synchronizer: "打轴",
-        gist: "Githu Gist",
+        gist: "Github Gist",
         preferences: "设置",
     },
 

--- a/src/languages/zh-HK.ts
+++ b/src/languages/zh-HK.ts
@@ -10,7 +10,7 @@ export const language = {
         home: "主頁",
         editor: "編輯",
         synchronizer: "同步",
-        gist: "Githu Gist",
+        gist: "Github Gist",
         preferences: "設定",
     },
 

--- a/src/languages/zh-TW.ts
+++ b/src/languages/zh-TW.ts
@@ -10,7 +10,7 @@ export const language = {
         home: "主頁",
         editor: "編輯",
         synchronizer: "同步",
-        gist: "Githu Gist",
+        gist: "Github Gist",
         preferences: "設定",
     },
 


### PR DESCRIPTION
This typo is already fixed in the Korean language.