### PR TITLE
feat: use wavesurfer.js to draw waveform on seekbar

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,10 @@
     },
     "dependencies": {
         "@lrc-maker/lrc-parser": "^0.1.17",
+        "@wavesurfer/react": "^1.0.11",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "wavesurfer.js": "^7.9.5"
     },
     "devDependencies": {
         "@swc/core": "^1.3.96",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,12 +8,18 @@ dependencies:
   '@lrc-maker/lrc-parser':
     specifier: ^0.1.17
     version: 0.1.17
+  '@wavesurfer/react':
+    specifier: ^1.0.11
+    version: 1.0.11(react@18.3.1)(wavesurfer.js@7.9.5)
   react:
     specifier: ^18.2.0
     version: 18.3.1
   react-dom:
     specifier: ^18.2.0
     version: 18.3.1(react@18.3.1)
+  wavesurfer.js:
+    specifier: ^7.9.5
+    version: 7.9.5
 
 devDependencies:
   '@swc/core':
@@ -723,6 +729,16 @@ packages:
       csstype: 3.1.3
     dev: true
 
+  /@wavesurfer/react@1.0.11(react@18.3.1)(wavesurfer.js@7.9.5):
+    resolution: {integrity: sha512-DRpaA3MRTKy4Jby12xvoHASa+w31FZtxaqanXcJjfqNqfamkKi8VJfRnz+Uub9LkpdgoAc3g5SuZF75lEcGgzQ==}
+    peerDependencies:
+      react: ^18.2.0 || ^19.0.0
+      wavesurfer.js: '>=7.7.14'
+    dependencies:
+      react: 18.3.1
+      wavesurfer.js: 7.9.5
+    dev: false
+
   /core-js@3.33.2:
     resolution: {integrity: sha512-XeBzWI6QL3nJQiHmdzbAOiMYqjrb7hwU7A39Qhvd/POSa/t9E1AeZyEZx3fNvp/vtM8zXwhoL0FsiS0hD0pruQ==}
     requiresBuild: true
@@ -1101,3 +1117,7 @@ packages:
     optionalDependencies:
       fsevents: 2.3.3
     dev: true
+
+  /wavesurfer.js@7.9.5:
+    resolution: {integrity: sha512-ioOG9chuAn0bF2NYYKkZtaxjcQK/hFskLg8ViLYbJHhWPk1N5wWtuqVhqeh2ZWT2SK3t0E8UkD7lLDLuZQQaSA==}
+    dev: false

--- a/src/components/audio.css
+++ b/src/components/audio.css
@@ -48,6 +48,14 @@ audio::-webkit-media-controls-enclosure {
     width: 100%;
 }
 
+.waveform-container {
+    flex: 1;
+}
+
+.waveform-container > .waveform {
+    height: 100%;
+}
+
 @media (width <= 768px) {
     .timeline-slider {
         --slider-height: 4px;
@@ -56,6 +64,19 @@ audio::-webkit-media-controls-enclosure {
         bottom: 100%;
         width: 100%;
         margin: 0;
+    }
+
+    .waveform-container {
+        position: absolute;
+        bottom: 100%;
+        margin: 0;
+        padding: 0 8px;
+        width: 100%;
+        background-color: var(--semi-black-color);
+    }
+
+    .app-main {
+        padding-bottom: 64px;
     }
 }
 

--- a/src/components/audio.tsx
+++ b/src/components/audio.tsx
@@ -104,7 +104,7 @@ const TimeLine: React.FC<{ duration: number; paused: boolean }> = ({ duration, p
     const { prefState } = useContext(appContext, ChangBits.prefState);
     const durationTimeTag = useMemo(() => {
         return duration ? " / " + convertTimeToTag(duration, prefState.fixed, false) : false;
-    }, [duration]);
+    }, [duration, prefState.fixed]);
 
     return (
         <>

--- a/src/components/audio.tsx
+++ b/src/components/audio.tsx
@@ -103,8 +103,9 @@ const TimeLine: React.FC<{ duration: number; paused: boolean }> = ({ duration, p
 
     const { prefState } = useContext(appContext, ChangBits.prefState);
     const durationTimeTag = useMemo(() => {
-        return duration ? " / " + convertTimeToTag(duration, prefState.fixed, false) : false;
-    }, [duration, prefState.fixed]);
+        const fixed = prefState.showWaveform ? prefState.fixed : 0;
+        return duration ? " / " + convertTimeToTag(duration, fixed, false) : false;
+    }, [duration, prefState.fixed, prefState.showWaveform]);
 
     return (
         <>

--- a/src/components/audio.tsx
+++ b/src/components/audio.tsx
@@ -1,5 +1,5 @@
 import { convertTimeToTag } from "@lrc-maker/lrc-parser";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import {
     AudioActionType,
     audioRef,
@@ -7,8 +7,10 @@ import {
     audioStatePubSub,
     currentTimePubSub,
 } from "../utils/audiomodule.js";
+import { appContext, ChangBits } from "./app.context";
 import { loadAudioDialogRef } from "./loadaudio.js";
 import { Forward5sSVG, LoadAudioSVG, PauseSVG, PlaySVG, Replay5sSVG } from "./svg.js";
+import { Waveform } from "./waveform";
 
 interface ISliderProps {
     min: number;
@@ -55,6 +57,8 @@ const TimeLine: React.FC<{ duration: number; paused: boolean }> = ({ duration, p
 
     useEffect(() => {
         if (paused) {
+            // update the value once when paused to reflect the exact time
+            setCurrentTime(audioRef.currentTime);
             // paused but user changing the time
             return currentTimePubSub.sub(self.current, (data) => {
                 setCurrentTime(data);
@@ -62,7 +66,7 @@ const TimeLine: React.FC<{ duration: number; paused: boolean }> = ({ duration, p
         } else {
             const id = setInterval(() => {
                 setCurrentTime(audioRef.currentTime);
-            }, 500 / rate);
+            }, 100 / rate); // redraw the waveform cursor faster
 
             return (): void => {
                 clearInterval(id);
@@ -72,32 +76,31 @@ const TimeLine: React.FC<{ duration: number; paused: boolean }> = ({ duration, p
 
     const rafId = useRef(0);
 
-    const onInput = useCallback((ev: React.ChangeEvent<HTMLInputElement>) => {
+    const onSeek = useCallback((time: number) => {
         if (rafId.current) {
             cancelAnimationFrame(rafId.current);
         }
 
-        const value = ev.target.value;
-
         rafId.current = requestAnimationFrame(() => {
-            const time = Number.parseInt(value, 10);
             setCurrentTime(time);
             audioRef.currentTime = time;
         });
     }, []);
 
+    const { prefState } = useContext(appContext, ChangBits.prefState);
     const durationTimeTag = useMemo(() => {
-        return duration ? " / " + convertTimeToTag(duration, 0, false) : false;
+        return duration ? " / " + convertTimeToTag(duration, prefState.fixed, false) : false;
     }, [duration]);
 
     return (
         <>
             <time>
-                {convertTimeToTag(currentTime, 0, false)}
+                {convertTimeToTag(currentTime, prefState.fixed, false)}
                 {durationTimeTag}
             </time>
-
-            <Slider min={0} max={duration} step={1} value={currentTime} className="timeline" onInput={onInput} />
+            <div className="slider waveform-container">
+                <Waveform value={currentTime} onSeek={onSeek} />
+            </div>
         </>
     );
 };

--- a/src/components/audio.tsx
+++ b/src/components/audio.tsx
@@ -76,6 +76,20 @@ const TimeLine: React.FC<{ duration: number; paused: boolean }> = ({ duration, p
 
     const rafId = useRef(0);
 
+    const onInput = useCallback((ev: React.ChangeEvent<HTMLInputElement>) => {
+        if (rafId.current) {
+            cancelAnimationFrame(rafId.current);
+        }
+
+        const value = ev.target.value;
+
+        rafId.current = requestAnimationFrame(() => {
+            const time = Number.parseInt(value, 10);
+            setCurrentTime(time);
+            audioRef.currentTime = time;
+        });
+    }, []);
+
     const onSeek = useCallback((time: number) => {
         if (rafId.current) {
             cancelAnimationFrame(rafId.current);
@@ -99,7 +113,18 @@ const TimeLine: React.FC<{ duration: number; paused: boolean }> = ({ duration, p
                 {durationTimeTag}
             </time>
             <div className="slider waveform-container">
-                <Waveform value={currentTime} onSeek={onSeek} />
+                {prefState.showWaveform
+                    ? <Waveform value={currentTime} onSeek={onSeek} />
+                    : (
+                        <Slider
+                            min={0}
+                            max={duration}
+                            step={1}
+                            value={currentTime}
+                            className="timeline"
+                            onInput={onInput}
+                        />
+                    )}
             </div>
         </>
     );

--- a/src/components/audio.tsx
+++ b/src/components/audio.tsx
@@ -102,15 +102,17 @@ const TimeLine: React.FC<{ duration: number; paused: boolean }> = ({ duration, p
     }, []);
 
     const { prefState } = useContext(appContext, ChangBits.prefState);
+
+    const fixed = prefState.showWaveform ? prefState.fixed : 0;
+
     const durationTimeTag = useMemo(() => {
-        const fixed = prefState.showWaveform ? prefState.fixed : 0;
         return duration ? " / " + convertTimeToTag(duration, fixed, false) : false;
-    }, [duration, prefState.fixed, prefState.showWaveform]);
+    }, [duration, fixed]);
 
     return (
         <>
             <time>
-                {convertTimeToTag(currentTime, prefState.fixed, false)}
+                {convertTimeToTag(currentTime, fixed, false)}
                 {durationTimeTag}
             </time>
             <div className="slider waveform-container">

--- a/src/components/preferences.tsx
+++ b/src/components/preferences.tsx
@@ -158,6 +158,15 @@ export const Preferences: React.FC = () => {
         [prefDispatch],
     );
 
+    const onShowWaveformToggle = useCallback(
+        () =>
+            prefDispatch({
+                type: "showWaveform",
+                payload: (prefState) => !prefState.showWaveform,
+            }),
+        [prefDispatch],
+    );
+
     const onScreenButtonToggle = useCallback(
         () =>
             prefDispatch({
@@ -317,7 +326,20 @@ export const Preferences: React.FC = () => {
                         </label>
                     </label>
                 </li>
-
+                <li>
+                    <label className="list-item">
+                        <span>{lang.preferences.showWaveform}</span>
+                        <label className="toggle-switch">
+                            <input
+                                type="checkbox"
+                                checked={prefState.showWaveform}
+                                onChange={onShowWaveformToggle}
+                                aria-label={lang.preferences.showWaveform}
+                            />
+                            <span className="toggle-switch-label" />
+                        </label>
+                    </label>
+                </li>
                 <li>
                     <section className="list-item">
                         <span>{lang.preferences.themeMode.label}</span>

--- a/src/components/waveform.css
+++ b/src/components/waveform.css
@@ -1,0 +1,15 @@
+.waveform {
+    position: relative;
+}
+
+.waveform::before {
+    content: "";
+    display: block;
+    position: absolute;
+    top: 50%;
+    height: 1px;
+    left: 0;
+    right: 0;
+    background-color: #eeeeee;
+    opacity: 0.5;
+}

--- a/src/components/waveform.tsx
+++ b/src/components/waveform.tsx
@@ -14,7 +14,7 @@ interface IWaveformProps {
 }
 
 export const Waveform: React.FC<IWaveformProps> = ({ value, onSeek, className }) => {
-    const containerRef = useRef<any>(null);
+    const containerRef = useRef<HTMLDivElement>(null);
 
     const style = getComputedStyle(document.documentElement);
     const themeColor = style.getPropertyValue("--theme-color");

--- a/src/components/waveform.tsx
+++ b/src/components/waveform.tsx
@@ -1,0 +1,51 @@
+import { useWavesurfer } from "@wavesurfer/react";
+import { useEffect, useRef } from "react";
+import { audioRef } from "../utils/audiomodule";
+import "./waveform.css";
+
+interface IWaveformProps {
+    // time in seconds
+    value: number;
+    /**
+     * @param time seconds
+     */
+    onSeek: (time: number) => void;
+    className?: string;
+}
+
+export const Waveform: React.FC<IWaveformProps> = ({ value, onSeek, className }) => {
+    const containerRef = useRef<any>(null);
+
+    const style = getComputedStyle(document.documentElement);
+    const themeColor = style.getPropertyValue("--theme-color");
+    const { wavesurfer } = useWavesurfer({
+        container: containerRef,
+        waveColor: "#eeeeee",
+        progressColor: themeColor,
+        cursorColor: themeColor,
+        normalize: true,
+        height: "auto",
+        interact: true,
+        dragToSeek: true,
+    });
+
+    // attach drag listener
+    useEffect(() => {
+        return wavesurfer?.on("interaction", (currentTime) => {
+            onSeek(currentTime);
+        });
+    }, [wavesurfer, onSeek]);
+
+    // Update the seekTo position when value prop changes
+    useEffect(() => {
+        wavesurfer?.setTime(value);
+    }, [wavesurfer, value]);
+
+    useEffect(() => {
+        wavesurfer?.load(audioRef.src).then(() => {
+            wavesurfer?.setTime(value);
+        });
+    }, [wavesurfer, audioRef.src]);
+
+    return <div className={`waveform ${className || ""}`} ref={containerRef}></div>;
+};

--- a/src/hooks/usePref.ts
+++ b/src/hooks/usePref.ts
@@ -25,6 +25,7 @@ const initState = {
     spaceEnd: 0,
     fixed: 3 as Fixed,
     builtInAudio: false,
+    showWaveform: true,
     screenButton: false,
     themeColor: themeColor.pink,
     themeMode: ThemeMode.auto,

--- a/src/languages/en-US.json
+++ b/src/languages/en-US.json
@@ -71,6 +71,7 @@
         "language": "Language",
         "builtInAudio": "Use browser built-in audio player",
         "spaceButton": "On-screen space key",
+        "showWaveform": "Show audio waveform in seek bar",
         "themeColor": "Theme color",
         "lrcFormat": "Change output format",
         "fixed": "Timestamp fixed",

--- a/src/languages/ja.json
+++ b/src/languages/ja.json
@@ -71,6 +71,7 @@
         "language": "言語(language)",
         "builtInAudio": "ブラウザ内蔵のオーディオプレーヤーを使用する",
         "spaceButton": "画面上のスペースキー",
+        "showWaveform": "音声波形を表示する",
         "themeColor": "テーマカラー",
         "lrcFormat": "歌詞出力フォーマット制御",
         "fixed": "タイムスタンプ小数点",

--- a/src/languages/ko-KR.json
+++ b/src/languages/ko-KR.json
@@ -71,6 +71,7 @@
         "language": "언어(language)",
         "builtInAudio": "브라우저 내장 오디오 재생기 사용하기",
         "spaceButton": "온 스크린 스페이스 키",
+        "showWaveform": "오디오 파형 표시",
         "themeColor": "테마 색",
         "lrcFormat": "LRC 파일 예시",
         "fixed": "시간 소숫점 자리수",

--- a/src/languages/pl-PL.json
+++ b/src/languages/pl-PL.json
@@ -71,6 +71,7 @@
         "language": "Język",
         "builtInAudio": "Użyj wbudowanego odtwarzacza audio przeglądarki",
         "spaceButton": "Klawisz spacji na ekranie",
+        "showWaveform": "Pokaż przebieg audio",
         "themeColor": "Kolor motywu",
         "lrcFormat": "Zmień format wyjściowy",
         "fixed": "Poprawka znacznika czasu",

--- a/src/languages/pt-BR.json
+++ b/src/languages/pt-BR.json
@@ -71,6 +71,7 @@
         "language": "Linguagem",
         "builtInAudio": "Use o player de áudio integrado do navegador",
         "spaceButton": "Tecla de espaço na tela",
+        "showWaveform": "Mostrar forma de onda de áudio",
         "themeColor": "Cor do tema",
         "lrcFormat": "Ajuste de formato LRC",
         "fixed": "Data-de-tempo fixo",

--- a/src/languages/sk-SK.json
+++ b/src/languages/sk-SK.json
@@ -71,6 +71,7 @@
         "language": "Jazyk",
         "builtInAudio": "Použite vstavaný prehrávač zvuku prehliadača",
         "spaceButton": "Medzerník na obrazovke",
+        "showWaveform": "Zobraziť vlnovú formu",
         "themeColor": "Farba motívu",
         "lrcFormat": "Zmeniť formát výstupu",
         "fixed": "Fixný časový údaj",

--- a/src/languages/zh-CN.json
+++ b/src/languages/zh-CN.json
@@ -65,6 +65,7 @@
         "language": "语言(language)",
         "builtInAudio": "使用浏览器内建音频播放器",
         "spaceButton": "启用虚拟空格键",
+        "showWaveform": "显示音频波形",
         "themeColor": "主题颜色",
         "lrcFormat": "歌词输出格式控制",
         "fixed": "时间标签小数点",

--- a/src/languages/zh-HK.json
+++ b/src/languages/zh-HK.json
@@ -65,6 +65,7 @@
         "language": "語言(language)",
         "builtInAudio": "使用瀏覽器內建音訊播放器",
         "spaceButton": "啓用螢幕 Space 鍵",
+        "showWaveform": "顯示音訊波形",
         "themeColor": "主題顏色",
         "lrcFormat": "歌詞輸出格式控制",
         "fixed": "時間標籤小數點",

--- a/src/languages/zh-TW.json
+++ b/src/languages/zh-TW.json
@@ -65,6 +65,7 @@
         "language": "語言(language)",
         "builtInAudio": "使用瀏覽器內建音訊播放器",
         "spaceButton": "啓用螢幕 Space 鍵",
+        "showWaveform": "顯示音訊波形",
         "themeColor": "主題顏色",
         "lrcFormat": "歌詞輸出格式控制",
         "fixed": "時間標籤小數點",


### PR DESCRIPTION
fix: format `durationTimeTag` with decimals specified in `prefState` (i.e. time label next to seekbar `00:00.000 / 01:22.333`)
fix: update the seekbar cursor with shorter interval (since the waveform is needed to watch the peek in real time)

closes https://github.com/magic-akari/lrc-maker/issues/139
